### PR TITLE
LOPL-1182 Remove incompatible patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 foo
 coverage
 Gemfile.lock
+.DS_Store
+spec/.DS_Store

--- a/lib/patches.rb
+++ b/lib/patches.rb
@@ -133,13 +133,3 @@ if need_passenger_patch
     end
   end
 end
-
-if defined?(Rails)
-  class SpawnlingCache < Rails::Railtie
-    initializer "cache" do
-      if defined?(::ActiveSupport::Cache::MemCacheStore) && Rails.cache.class.name == 'ActiveSupport::Cache::MemCacheStore'
-        ::ActiveSupport::Cache::MemCacheStore.delegate :reset, :to => :@data
-      end
-    end
-  end
-end

--- a/lib/spawnling/version.rb
+++ b/lib/spawnling/version.rb
@@ -1,3 +1,3 @@
 class Spawnling
-  VERSION = '2.1.6'
+  VERSION = '2.1.7'
 end

--- a/spawnling.gemspec
+++ b/spawnling.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.authors       = ['Tom Anderson', 'Michael Noack']
   s.email         = ['tom@squeat.com', 'michael+spawnling@noack.com.au']
 
-  s.homepage      = %q{https://github.com/tra/spawnling}
+  s.homepage      = %q{https://github.com/fluxfederation/spawnling}
   s.license       = "MIT"
   s.summary       = %q{Easily fork OR thread long-running sections of code in Ruby}
   s.description   = %q{This plugin provides a 'Spawnling' class to easily fork OR


### PR DESCRIPTION
This will make spawnling compatible with Rails 7.1
It will no longer attempt to call 'reset' on an instance of ConnectionPool.
Seems to work just fine